### PR TITLE
MAINT get rid of compiler warnings

### DIFF
--- a/linear.cpp
+++ b/linear.cpp
@@ -1010,7 +1010,7 @@ static void solve_l2r_l1l2_svr(
 	double d, G, H;
 	double Gmax_old = INF;
 	double Gmax_new, Gnorm1_new;
-	double Gnorm1_init;
+	double Gnorm1_init = 0.;
 	double *beta = new double[l];
 	double *QD = new double[l];
 	double *y = prob->y;
@@ -1409,7 +1409,7 @@ static void solve_l1r_l2_svc(
 	double d, G_loss, G, H;
 	double Gmax_old = INF;
 	double Gmax_new, Gnorm1_new;
-	double Gnorm1_init;
+	double Gnorm1_init = 0.;
 	double d_old, d_diff;
 	double loss_old, loss_new;
 	double appxcond, cond;
@@ -1699,7 +1699,7 @@ static void solve_l1r_lr(
 	double sigma = 0.01;
 	double w_norm, w_norm_new;
 	double z, G, H;
-	double Gnorm1_init;
+	double Gnorm1_init = 0.;
 	double Gmax_old = INF;
 	double Gmax_new, Gnorm1_new;
 	double QP_Gmax_old = INF;


### PR DESCRIPTION
Here's a patch from the scikit-learn fork of Liblinear. It doesn't do much, but it shuts up the compiler.
