### PR TITLE
Add Normalisation Option

### DIFF
--- a/linear.cpp
+++ b/linear.cpp
@@ -2620,6 +2620,8 @@ int save_model(const char *model_file_name, const struct model *model_)
 
 	fprintf(fp, "bias %.16g\n", model_->bias);
 
+	fprintf(fp, "normalization %d\n", model_->normal);
+
 	fprintf(fp, "w\n");
 	for(i=0; i<w_size; i++)
 	{
@@ -2645,6 +2647,7 @@ struct model *load_model(const char *model_file_name)
 	int nr_feature;
 	int n;
 	int nr_class;
+	int normalfac;
 	double bias;
 	model *model_ = Malloc(model,1);
 	parameter& param = model_->param;
@@ -2685,6 +2688,11 @@ struct model *load_model(const char *model_file_name)
 		{
 			fscanf(fp,"%d",&nr_class);
 			model_->nr_class=nr_class;
+		}
+		else if(strcmp(cmd,"normalization")==0)
+		{
+			fscanf(fp,"%d",&normalfac);
+			model_->normal=normalfac;
 		}
 		else if(strcmp(cmd,"nr_feature")==0)
 		{

--- a/linear.h
+++ b/linear.h
@@ -39,6 +39,7 @@ struct model
 	struct parameter param;
 	int nr_class;		/* number of classes */
 	int nr_feature;
+	int normal;
 	double *w;
 	int *label;		/* label of each class */
 	double bias;

--- a/predict.c
+++ b/predict.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <ctype.h>
 #include <stdlib.h>
+#include <math.h>
 #include <string.h>
 #include <errno.h>
 #include "linear.h"
@@ -132,6 +133,17 @@ void do_predict(FILE *input, FILE *output)
 			i++;
 		}
 		x[i].index = -1;
+
+		if(model_->normal){
+			double length = 0;
+			for(int kk = 0; x[kk].index != -1; kk++)
+				length += x[kk].value * x[kk].value;
+	
+			length = sqrt(length);
+			
+			for(int kk = 0; x[kk].index != -1; kk++)
+				x[kk].value /= length;
+		}
 
 		if(flag_predict_probability)
 		{

--- a/train.c
+++ b/train.c
@@ -93,6 +93,24 @@ int flag_cross_validation;
 int nr_fold;
 double bias;
 
+int normal = 0;
+
+void normalize(problem *pb){
+	feature_node **p = pb->x;
+	
+	for(int i = 0; i < pb->l; i++){
+		double length = 0;
+
+		for(int j = 0; p[i][j].index != -1; j++)
+			length += (p[i][j].value) * (p[i][j].value);
+
+		length = sqrt(length);
+
+		for(int j = 0; p[i][j].index != -1; j++)
+			p[i][j].value /= length;
+	}
+}
+
 int main(int argc, char **argv)
 {
 	char input_file_name[1024];
@@ -101,6 +119,7 @@ int main(int argc, char **argv)
 
 	parse_command_line(argc, argv, input_file_name, model_file_name);
 	read_problem(input_file_name);
+	if(normal) normalize(&prob);
 	error_msg = check_parameter(&prob,&param);
 
 	if(error_msg)
@@ -116,6 +135,7 @@ int main(int argc, char **argv)
 	else
 	{
 		model_=train(&prob, &param);
+		model_->normal = normal;
 		if(save_model(model_file_name, model_))
 		{
 			fprintf(stderr,"can't save model to file %s\n",model_file_name);
@@ -197,6 +217,11 @@ void parse_command_line(int argc, char **argv, char *input_file_name, char *mode
 			exit_with_help();
 		switch(argv[i-1][1])
 		{
+			case 'n':
+				normal = 1;
+				i--;
+				break;
+
 			case 's':
 				param.solver_type = atoi(argv[i]);
 				break;
@@ -252,7 +277,7 @@ void parse_command_line(int argc, char **argv, char *input_file_name, char *mode
 	// determine filenames
 	if(i>=argc)
 		exit_with_help();
-
+	
 	strcpy(input_file_name, argv[i]);
 
 	if(i<argc-1)


### PR DESCRIPTION
With -n option added when executing train, It would normalize every instance so it become unit length in Euclidean norm. And the .model file would have a line of "normalization 1" in it. (if -n is not added, then it would be "normalization 0") So when you execute predict with that .model file, it will also do the normalization on the test data. (Thus the old .model file would be deprecated)

Example:
train -s 7 -n -e 1e-6 covtype.libsvm.binary

Some comparison:
train -s 0 -e 1e-6 covtype.libsvm.binary: 0m39.492s, with -n: 0m04.001s
train -s 1 -e 1e-6 covtype.libsvm.binary: 2m47.380s, with -n: 0m10.116s
train -s 2 -e 1e-6 covtype.libsvm.binary: 0m38.217s, with -n: 0m05.072s
train -s 7 -e 1e-6 covtype.libsvm.binary: 3m42.433s, with -n: 0m07.034s

train -s 1 -e 1e-6 splice.txt
predict splice.t splice.txt.model out.txt: 84.2299%, with -n: 84.9655%

train -s 1 -e 1e-6 a9a.txt
predict a9a.t a9a.txt.model out.txt: 84.9395%, with -n: 85.0132%

train -s ALPHA -e 1e-6 w1a.txt
predict w1a.t w1a.txt.model out.txt: 96.9221%, with -n: 97.6625%
ALPHA from 0 to 7: (without -n)
Accuracy = 97.2902% (45991/47272)
Accuracy = 96.8903% (45802/47272)
Accuracy = 96.9221% (45817/47272)
Accuracy = 97.1019% (45902/47272)
Accuracy = 96.8523% (45784/47272)
Accuracy = 97.3959% (46041/47272)
Accuracy = 97.5736% (46125/47272)
Accuracy = 97.2902% (45991/47272)
(with -n)
Accuracy = 97.5144% (46097/47272)
Accuracy = 97.6646% (46168/47272)
Accuracy = 97.6625% (46167/47272)
Accuracy = 97.6455% (46159/47272)
Accuracy = 97.635% (46154/47272)
Accuracy = 97.745% (46206/47272)
Accuracy = 97.3473% (46018/47272)
Accuracy = 97.5144% (46097/47272)

train -s ALPHA -e 1e-6 svmguide1.txt
predict svmguide1.t svmguide1.txt.model out.txt
ALPHA from 0 to 7: (without -n)
Accuracy = 79.025% (3161/4000)
Accuracy = 78.95% (3158/4000)
Accuracy = 78.925% (3157/4000)
Accuracy = 59.125% (2365/4000)
Accuracy = 76.625% (3065/4000)
Accuracy = 78.9% (3156/4000)
Accuracy = 79.025% (3161/4000)
Accuracy = 80.125% (3205/4000)
(with -n)
Accuracy = 78.4% (3136/4000)
Accuracy = 78.425% (3137/4000)
Accuracy = 78.425% (3137/4000)
Accuracy = 78.3% (3132/4000)
Accuracy = 78.5% (3140/4000)
Accuracy = 79.025% (3161/4000)
Accuracy = 78.225% (3129/4000)
Accuracy = 78.4% (3136/4000)

It is basically a lot faster with similar accuracy.
