### PR TITLE
Consistent memory allocation and memory leak prevention

### DIFF
--- a/linear.cpp
+++ b/linear.cpp
@@ -2771,7 +2771,7 @@ void free_and_destroy_model(struct model **model_ptr_ptr)
 	if(model_ptr != NULL)
 	{
 		free_model_content(model_ptr);
-		delete model_ptr;
+		delete[] model_ptr;
 		*model_ptr_ptr = 0;
 	}
 }

--- a/linear.cpp
+++ b/linear.cpp
@@ -30,13 +30,17 @@ static void print_string_stdout(const char *s)
 
 static void (*liblinear_print_string) (const char *) = &print_string_stdout;
 
+#ifdef _MSC_VER
+#pragma warning (disable:4996) // 'vsnprintf': This function or variable may be unsafe.
+#endif // _MSC_VER
+
 #if 1
 static void info(const char *fmt,...)
 {
 	char buf[BUFSIZ];
 	va_list ap;
 	va_start(ap,fmt);
-	vsprintf(buf,fmt,ap);
+	vsnprintf(buf,BUFSIZ,fmt,ap);
 	va_end(ap);
 	(*liblinear_print_string)(buf);
 }

--- a/linear.h
+++ b/linear.h
@@ -42,6 +42,9 @@ struct model
 	double *w;
 	int *label;		/* label of each class */
 	double bias;
+
+	model();
+	~model();
 };
 
 struct model* train(const struct problem *prob, const struct parameter *param);

--- a/memory_buffer.h
+++ b/memory_buffer.h
@@ -58,7 +58,7 @@ inline TItemType* CBuffer<TItemType>::Detach()
 	TItemType* tmp = ptr;
 	ptr = 0;
 	count = 0;
-	return ptr;
+	return tmp;
 }
 
 template<typename TItemType>

--- a/memory_buffer.h
+++ b/memory_buffer.h
@@ -1,0 +1,78 @@
+#ifndef _MEMORY_BUFFER
+#define _MEMORY_BUFFER
+
+#include <assert.h>
+
+// Simple memory buffer for RAII
+template<typename TItemType>
+class CBuffer {
+public:
+	CBuffer() : count( 0 ), ptr( 0 ) {}
+	explicit CBuffer( size_t count );
+	~CBuffer();
+
+	size_t Count() const { return count; }
+
+	TItemType* Detach();
+	void Realloc( size_t new_size );
+
+	TItemType& operator[]( int index ) { assert( ptr != 0 ); return ptr[index]; }
+	TItemType* operator->() { assert( count == 1 ); return ptr; }
+	operator TItemType*() { return ptr; } // bad idea, but less code changed
+
+	// Better way, may be in future
+	TItemType* Ptr() { assert( ptr != 0 ); return ptr; }
+
+private:
+	size_t count;
+	TItemType* ptr;
+
+	// prohibited
+	CBuffer( const CBuffer<TItemType>& other );
+	const CBuffer<TItemType>& operator=( const CBuffer<TItemType>& other );
+};
+
+// ----------------------------------------------------------------------------
+
+template<typename TItemType>
+inline CBuffer<TItemType>::CBuffer( size_t _count ) :
+count( _count ),
+	ptr( 0 )
+{
+	assert( count > 0 );
+	ptr = new TItemType[count];
+}
+
+template<typename TItemType>
+inline CBuffer<TItemType>::~CBuffer()
+{
+	if( ptr != 0 ) {
+		delete[] ptr;
+		ptr = 0;
+	}
+}
+
+template<typename TItemType>
+inline TItemType* CBuffer<TItemType>::Detach()
+{
+	TItemType* tmp = ptr;
+	ptr = 0;
+	count = 0;
+	return ptr;
+}
+
+template<typename TItemType>
+inline void CBuffer<TItemType>::Realloc( size_t new_count )
+{
+	assert( new_count > count );
+	TItemType* buffer = new TItemType[new_count];
+	if( count > 0 ) {
+		::memcpy( buffer, ptr, count * sizeof( TItemType ) );
+		delete[] Detach();
+	}
+
+	ptr = buffer;
+	count = new_count;
+}
+
+#endif // _MEMORY_BUFFER

--- a/tron.cpp
+++ b/tron.cpp
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <stdarg.h>
 #include "tron.h"
+#include "memory_buffer.h"
 
 #ifndef min
 template <class T> static inline T min(T x,T y) { return (x<y)?x:y; }
@@ -70,10 +71,10 @@ void TRON::tron(double *w)
 	double delta, snorm, one=1.0;
 	double alpha, f, fnew, prered, actred, gs;
 	int search = 1, iter = 1, inc = 1;
-	double *s = new double[n];
-	double *r = new double[n];
-	double *w_new = new double[n];
-	double *g = new double[n];
+	CBuffer<double> s(n);
+	CBuffer<double> r(n);
+	CBuffer<double> w_new(n);
+	CBuffer<double> g(n);
 
 	for (i=0; i<n; i++)
 		w[i] = 0;
@@ -154,11 +155,6 @@ void TRON::tron(double *w)
 			break;
 		}
 	}
-
-	delete[] g;
-	delete[] r;
-	delete[] w_new;
-	delete[] s;
 }
 
 int TRON::trcg(double delta, double *g, double *s, double *r)
@@ -166,8 +162,8 @@ int TRON::trcg(double delta, double *g, double *s, double *r)
 	int i, inc = 1;
 	int n = fun_obj->get_nr_variable();
 	double one = 1;
-	double *d = new double[n];
-	double *Hd = new double[n];
+	CBuffer<double> d(n);
+	CBuffer<double> Hd(n);
 	double rTr, rnewTrnew, alpha, beta, cgtol;
 
 	for (i=0; i<n; i++)
@@ -217,9 +213,6 @@ int TRON::trcg(double delta, double *g, double *s, double *r)
 		daxpy_(&n, &one, r, &inc, d, &inc);
 		rTr = rnewTrnew;
 	}
-
-	delete[] d;
-	delete[] Hd;
 
 	return(cg_iter);
 }

--- a/tron.cpp
+++ b/tron.cpp
@@ -12,6 +12,10 @@ template <class T> static inline T min(T x,T y) { return (x<y)?x:y; }
 template <class T> static inline T max(T x,T y) { return (x>y)?x:y; }
 #endif
 
+#ifdef _MSC_VER
+#pragma warning (disable:4996) // 'vsnprintf': This function or variable may be unsafe.
+#endif // _MSC_VER
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -36,7 +40,7 @@ void TRON::info(const char *fmt,...)
 	char buf[BUFSIZ];
 	va_list ap;
 	va_start(ap,fmt);
-	vsprintf(buf,fmt,ap);
+	vsnprintf(buf,BUFSIZ,fmt,ap);
 	va_end(ap);
 	(*tron_print_string)(buf);
 }


### PR DESCRIPTION
Hi.
This patch aims to prevent memory leaks in the situation of out of memory.
It is done by eliminating alloc/free pairs with single CBuffer object, which deletes corresponding memory automatically in destructor (RAII).
So now throwing of std::bad_alloc (or any other exception in new) is safe, all memory will be freed.
Also all malloc/free operators substituted with new/delete (It is not recommended to mix them in the same program).

Comparing to Pull Request #4, this variant does not use std::vector (it can be inconvenient in some cases) and this patch changes all memory allocations in one time.

Codestyle is subject to discuss, so I can change it (or you can do it easily by yourself).