### PR TITLE
add init_sol to parameter struct.

### DIFF
--- a/README
+++ b/README
@@ -350,6 +350,7 @@ Library Usage
                 int *weight_label;
                 double* weight;
                 double p;
+                double *init_sol;
         };
 
     solver_type can be one of L2R_LR, L2R_L2LOSS_SVC_DUAL, L2R_L2LOSS_SVC, L2R_L1LOSS_SVC_DUAL, MCSVM_CS, L1R_L2LOSS_SVC, L1R_LR, L2R_LR_DUAL, L2R_L2LOSS_SVR, L2R_L2LOSS_SVR_DUAL, L2R_L1LOSS_SVR_DUAL.
@@ -370,6 +371,7 @@ Library Usage
     C is the cost of constraints violation.
     p is the sensitiveness of loss of support vector regression. 
     eps is the stopping criterion.
+    init_sol is the initial solution specification support for solver L2R_LR and L2R_L2LOSS_SVC.
 
     nr_weight, weight_label, and weight are used to change the penalty
     for some classes (If the weight for a class is not changed, it is


### PR DESCRIPTION
init_sol is the initial solution specification support for solver L2R_LR and L2R_L2LOSS_SVC.