### PR TITLE
Fixed bug : random number generator under Windows 32/64

### DIFF
--- a/linear.h
+++ b/linear.h
@@ -45,6 +45,11 @@ struct model
 	double bias;
 };
 
+#ifdef _WIN32
+// new function to check random number generation fix
+const char *check_rand_fixed();
+#endif 
+
 struct model* train(const struct problem *prob, const struct parameter *param);
 void cross_validation(const struct problem *prob, const struct parameter *param, int nr_fold, double *target);
 void find_parameter_C(const struct problem *prob, const struct parameter *param, int nr_fold, double start_C, double max_C, double *best_C, double *best_rate);

--- a/train.c
+++ b/train.c
@@ -100,6 +100,18 @@ double bias;
 
 int main(int argc, char **argv)
 {
+	
+#ifdef _WIN32
+	// Auto-check random number generator fix at startup
+	const char *error_msg_rand;
+	error_msg_rand = check_rand_fixed();
+	if (error_msg_rand)
+	{
+		fprintf(stderr, "ERROR: %s\n", error_msg_rand);
+		exit(1);
+	}
+#endif 
+
 	char input_file_name[1024];
 	char model_file_name[1024];
 	const char *error_msg;


### PR DESCRIPTION
Fixed bug : under windows, some problems required a lot more iterations to converge, than the hardcoded max number (for example this max number is 1000 in solve_l2r_l1l2_svc). Therefore we had to recompile the code with a larger max number to make it reach the same results than under Linux.

This issue is explained in the liblinear [FAQ](http://www.csie.ntu.edu.tw/~cjlin/liblinear/FAQ.html) under "Windows Binary Files" section but the fix provided in the FAQis actually incorrect and not valid for both 32-bit and 64-bit systems.

This commit fixes the random number generator for windows, to make it work the same way than in Linux. It also includes an auto-check performed at startup.