### PR TITLE
zero initialize parameter struct and add liblinear version number

### DIFF
--- a/linear.cpp
+++ b/linear.cpp
@@ -2810,13 +2810,13 @@ struct model *load_model(const char *model_file_name)
 	model *model_ = Malloc(model,1);
 	parameter& param = model_->param;
 
-        param.C = 1;
-        param.p = .1;
-        param.eps = INF;
-        param.nr_weight = 0;
-        param.weight_label = NULL;
-        param.weight = NULL;
-        param.init_sol = NULL;
+	param.C = 1;
+	param.p = .1;
+	param.eps = INF;
+	param.nr_weight = 0;
+	param.weight_label = NULL;
+	param.weight = NULL;
+	param.init_sol = NULL;
 
 	model_->label = NULL;
 

--- a/linear.cpp
+++ b/linear.cpp
@@ -6,6 +6,7 @@
 #include <locale.h>
 #include "linear.h"
 #include "tron.h"
+int liblinear_version = LIBLINEAR_VERSION;
 typedef signed char schar;
 template <class T> static inline void swap(T& x, T& y) { T t=x; x=y; y=t; }
 #ifndef min

--- a/linear.cpp
+++ b/linear.cpp
@@ -183,7 +183,7 @@ void l2r_lr_fun::Hv(double *s, double *Hs)
 	{
 		feature_node * const xi=x[i];
 		wa[i] = sparse_operator::dot(s, xi);
-		
+
 		wa[i] = C[i]*D[i]*wa[i];
 
 		sparse_operator::axpy(wa[i], xi, Hs);
@@ -322,7 +322,7 @@ void l2r_l2_svc_fun::Hv(double *s, double *Hs)
 	{
 		feature_node * const xi=x[I[i]];
 		wa[i] = sparse_operator::dot(s, xi);
-		
+
 		wa[i] = C[I[i]]*wa[i];
 
 		sparse_operator::axpy(wa[i], xi, Hs);
@@ -432,19 +432,19 @@ void l2r_l2_svr_fun::grad(double *w, double *g)
 		g[i] = w[i] + 2*g[i];
 }
 
-// A coordinate descent algorithm for 
+// A coordinate descent algorithm for
 // multi-class support vector machines by Crammer and Singer
 //
 //  min_{\alpha}  0.5 \sum_m ||w_m(\alpha)||^2 + \sum_i \sum_m e^m_i alpha^m_i
 //    s.t.     \alpha^m_i <= C^m_i \forall m,i , \sum_m \alpha^m_i=0 \forall i
-// 
+//
 //  where e^m_i = 0 if y_i  = m,
 //        e^m_i = 1 if y_i != m,
-//  C^m_i = C if m  = y_i, 
-//  C^m_i = 0 if m != y_i, 
-//  and w_m(\alpha) = \sum_i \alpha^m_i x_i 
+//  C^m_i = C if m  = y_i,
+//  C^m_i = 0 if m != y_i,
+//  and w_m(\alpha) = \sum_i \alpha^m_i x_i
 //
-// Given: 
+// Given:
 // x, y, C
 // eps is the stopping tolerance
 //
@@ -552,7 +552,7 @@ void Solver_MCSVM_CS::Solve(double *w)
 	double eps_shrink = max(10.0*eps, 1.0); // stopping tolerance for shrinking
 	bool start_from_all = true;
 
-	// Initial alpha can be set here. Note that 
+	// Initial alpha can be set here. Note that
 	// sum_m alpha[i*nr_class+m] = 0, for all i=1,...,l-1
 	// alpha[i*nr_class+m] <= C[GETI(i)] if prob->y[i] == m
 	// alpha[i*nr_class+m] <= 0 if prob->y[i] != m
@@ -747,14 +747,14 @@ void Solver_MCSVM_CS::Solve(double *w)
 	delete [] active_size_i;
 }
 
-// A coordinate descent algorithm for 
+// A coordinate descent algorithm for
 // L1-loss and L2-loss SVM dual problems
 //
 //  min_\alpha  0.5(\alpha^T (Q + D)\alpha) - e^T \alpha,
 //    s.t.      0 <= \alpha_i <= upper_bound_i,
-// 
+//
 //  where Qij = yi yj xi^T xj and
-//  D is a diagonal matrix 
+//  D is a diagonal matrix
 //
 // In L1-SVM case:
 // 		upper_bound_i = Cp if y_i = 1
@@ -765,12 +765,12 @@ void Solver_MCSVM_CS::Solve(double *w)
 // 		D_ii = 1/(2*Cp)	if y_i = 1
 // 		D_ii = 1/(2*Cn)	if y_i = -1
 //
-// Given: 
+// Given:
 // x, y, Cp, Cn
 // eps is the stopping tolerance
 //
 // solution will be put in w
-// 
+//
 // See Algorithm 3 of Hsieh et al., ICML 2008
 
 #undef GETI
@@ -952,14 +952,14 @@ static void solve_l2r_l1l2_svc(
 }
 
 
-// A coordinate descent algorithm for 
+// A coordinate descent algorithm for
 // L1-loss and L2-loss epsilon-SVR dual problem
 //
 //  min_\beta  0.5\beta^T (Q + diag(lambda)) \beta - p \sum_{i=1}^l|\beta_i| + \sum_{i=1}^l yi\beta_i,
 //    s.t.      -upper_bound_i <= \beta_i <= upper_bound_i,
-// 
+//
 //  where Qij = xi^T xj and
-//  D is a diagonal matrix 
+//  D is a diagonal matrix
 //
 // In L1-SVM case:
 // 		upper_bound_i = C
@@ -968,13 +968,13 @@ static void solve_l2r_l1l2_svc(
 // 		upper_bound_i = INF
 // 		lambda_i = 1/(2*C)
 //
-// Given: 
+// Given:
 // x, y, p, C
 // eps is the stopping tolerance
 //
 // solution will be put in w
 //
-// See Algorithm 4 of Ho and Lin, 2012   
+// See Algorithm 4 of Ho and Lin, 2012
 
 #undef GETI
 #define GETI(i) (0)
@@ -1166,17 +1166,17 @@ static void solve_l2r_l1l2_svr(
 }
 
 
-// A coordinate descent algorithm for 
+// A coordinate descent algorithm for
 // the dual of L2-regularized logistic regression problems
 //
 //  min_\alpha  0.5(\alpha^T Q \alpha) + \sum \alpha_i log (\alpha_i) + (upper_bound_i - \alpha_i) log (upper_bound_i - \alpha_i),
 //    s.t.      0 <= \alpha_i <= upper_bound_i,
-// 
-//  where Qij = yi yj xi^T xj and 
+//
+//  where Qij = yi yj xi^T xj and
 //  upper_bound_i = Cp if y_i = 1
 //  upper_bound_i = Cn if y_i = -1
 //
-// Given: 
+// Given:
 // x, y, Cp, Cn
 // eps is the stopping tolerance
 //
@@ -1195,7 +1195,7 @@ void solve_l2r_lr_dual(const problem *prob, double *w, double eps, double Cp, do
 	int i, s, iter = 0;
 	double *xTx = new double[l];
 	int max_iter = 1000;
-	int *index = new int[l];	
+	int *index = new int[l];
 	double *alpha = new double[2*l]; // store alpha and C - alpha
 	schar *y = new schar[l];
 	int max_inner_iter = 100; // for inner Newton
@@ -1214,7 +1214,7 @@ void solve_l2r_lr_dual(const problem *prob, double *w, double eps, double Cp, do
 			y[i] = -1;
 		}
 	}
-	
+
 	// Initial alpha can be set here. Note that
 	// 0 < alpha[i] < upper_bound[GETI(i)]
 	// alpha[2*i] + alpha[2*i+1] = upper_bound[GETI(i)]
@@ -1329,12 +1329,12 @@ void solve_l2r_lr_dual(const problem *prob, double *w, double eps, double Cp, do
 	delete [] index;
 }
 
-// A coordinate descent algorithm for 
+// A coordinate descent algorithm for
 // L1-regularized L2-loss support vector classification
 //
 //  min_w \sum |wj| + C \sum max(0, 1-yi w^T xi)^2,
 //
-// Given: 
+// Given:
 // x, y, Cp, Cn
 // eps is the stopping tolerance
 //
@@ -1608,12 +1608,12 @@ static void solve_l1r_l2_svc(
 	delete [] xj_sq;
 }
 
-// A coordinate descent algorithm for 
+// A coordinate descent algorithm for
 // L1-regularized logistic regression problems
 //
 //  min_w \sum |wj| + C \sum log(1+exp(-yi w^T xi)),
 //
-// Given: 
+// Given:
 // x, y, Cp, Cn
 // eps is the stopping tolerance
 //
@@ -2076,8 +2076,8 @@ static void group_classes(const problem *prob, int *nr_class_ret, int **label_re
 	}
 
 	//
-	// Labels are ordered by their first occurrence in the training set. 
-	// However, for two-class sets with -1/+1 labels and -1 appears first, 
+	// Labels are ordered by their first occurrence in the training set.
+	// However, for two-class sets with -1/+1 labels and -1 appears first,
 	// we swap labels to ensure that internally the binary SVM has positive data corresponding to the +1 instances.
 	//
 	if (nr_class == 2 && label[0] == -1 && label[1] == 1)
@@ -2351,7 +2351,7 @@ model* train(const problem *prob, const parameter *param)
 					sub_prob.y[k] = +1;
 				for(; k<sub_prob.l; k++)
 					sub_prob.y[k] = -1;
-				
+
 				if(param->init_sol != NULL)
 					for(i=0;i<w_size;i++)
 						model_->w[i] = param->init_sol[i];
@@ -2602,7 +2602,7 @@ void find_parameter_C(const problem *prob, const parameter *param, int nr_fold, 
 		param1.C = param1.C*ratio;
 	}
 
-	if(param1.C > max_C && max_C > start_C) 
+	if(param1.C > max_C && max_C > start_C)
 		info("warning: maximum C reached.\n");
 	free(fold_start);
 	free(perm);
@@ -2933,7 +2933,7 @@ void get_labels(const model *model_, int* label)
 }
 
 // use inline here for better performance (around 20% faster than the non-inline one)
-static inline double get_w_value(const struct model *model_, int idx, int label_idx) 
+static inline double get_w_value(const struct model *model_, int idx, int label_idx)
 {
 	int nr_class = model_->nr_class;
 	int solver_type = model_->param.solver_type;
@@ -2943,7 +2943,7 @@ static inline double get_w_value(const struct model *model_, int idx, int label_
 		return 0;
 	if(check_regression_model(model_))
 		return w[idx];
-	else 
+	else
 	{
 		if(label_idx < 0 || label_idx >= nr_class)
 			return 0;
@@ -3031,7 +3031,7 @@ const char *check_parameter(const problem *prob, const parameter *param)
 		&& param->solver_type != L2R_L1LOSS_SVR_DUAL)
 		return "unknown solver type";
 
-	if(param->init_sol != NULL 
+	if(param->init_sol != NULL
 		&& param->solver_type != L2R_LR && param->solver_type != L2R_L2LOSS_SVC)
 		return "Initial-solution specification supported only for solver L2R_LR and L2R_L2LOSS_SVC";
 

--- a/linear.cpp
+++ b/linear.cpp
@@ -2809,6 +2809,14 @@ struct model *load_model(const char *model_file_name)
 	model *model_ = Malloc(model,1);
 	parameter& param = model_->param;
 
+        param.C = 1;
+        param.p = .1;
+        param.eps = INF;
+        param.nr_weight = 0;
+        param.weight_label = NULL;
+        param.weight = NULL;
+        param.init_sol = NULL;
+
 	model_->label = NULL;
 
 	char *old_locale = setlocale(LC_ALL, NULL);

--- a/linear.h
+++ b/linear.h
@@ -1,9 +1,13 @@
 #ifndef _LIBLINEAR_H
 #define _LIBLINEAR_H
 
+#define LIBLINEAR_VERSION 210
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+extern int liblinear_version;
 
 struct feature_node
 {


### PR DESCRIPTION
to prevent interfacing libraries from crashing when destroying the model struct returned from load_model, nr_weight, weight and weight_label should be set to 0.

to mirror libsvm, there should be a liblinear_version number