### PR TITLE
set default param.nr_weight = 0

### DIFF
--- a/linear.cpp
+++ b/linear.cpp
@@ -2802,6 +2802,7 @@ struct model *load_model(const char *model_file_name)
 	double bias;
 	model *model_ = Malloc(model,1);
 	parameter& param = model_->param;
+	param.nr_weight = 0;
 
 	model_->label = NULL;
 


### PR DESCRIPTION
following up an an earlier pull request:

load_model does not zero-initialize the param object, thus allowing its values to be randomly set. 

in order to externalize this object into another language (such as kdb+), we need to know the correct value of nr_weight.   without this being set to 0, the externalization code will think the following 3 arrays have (potentially very large) non-zero length:

weight_label
weight
init_sol