### PR TITLE
predict: add support for -b2 (softmax probs) and -b3 (raw scores)

### DIFF
--- a/linear.cpp
+++ b/linear.cpp
@@ -2855,6 +2855,24 @@ double predict_probability(const struct model *model_, const struct feature_node
 		return 0;
 }
 
+double predict_softmax_probability(const struct model *model_, const struct feature_node *x, double* prob_estimates)
+{
+	int i;
+	int nr_class=model_->nr_class;
+
+	double label=predict_values(model_, x, prob_estimates);
+	double sum = 0.0;
+	for(i=0;i<nr_class;i++) {
+		prob_estimates[i]=exp(prob_estimates[i]);
+		sum += prob_estimates[i];
+	}
+
+	for(i=0;i<nr_class;i++)
+		prob_estimates[i]=prob_estimates[i]/sum;
+
+	return label;
+}
+
 static const char *solver_type_table[]=
 {
 	"L2R_LR", "L2R_L2LOSS_SVC_DUAL", "L2R_L2LOSS_SVC", "L2R_L1LOSS_SVC_DUAL", "MCSVM_CS",

--- a/linear.h
+++ b/linear.h
@@ -56,6 +56,7 @@ void find_parameters(const struct problem *prob, const struct parameter *param, 
 double predict_values(const struct model *model_, const struct feature_node *x, double* dec_values);
 double predict(const struct model *model_, const struct feature_node *x);
 double predict_probability(const struct model *model_, const struct feature_node *x, double* prob_estimates);
+double predict_softmax_probability(const struct model *model_, const struct feature_node *x, double* prob_estimates);
 
 int save_model(const char *model_file_name, const struct model *model_);
 struct model *load_model(const char *model_file_name);

--- a/predict.c
+++ b/predict.c
@@ -62,7 +62,7 @@ void do_predict(FILE *input, FILE *output)
 	{
 		int *labels;
 
-		if(!check_probability_model(model_))
+		if(flag_predict_probability == 1 && !check_probability_model(model_))
 		{
 			fprintf(stderr, "probability output is only supported for logistic regression\n");
 			exit(1);
@@ -136,7 +136,18 @@ void do_predict(FILE *input, FILE *output)
 		if(flag_predict_probability)
 		{
 			int j;
-			predict_label = predict_probability(model_,x,prob_estimates);
+			predict_label = 0.0;
+			switch(flag_predict_probability) {
+				case 1:
+					predict_label = predict_probability(model_,x,prob_estimates);
+					break;
+				case 2:
+					predict_label = predict_softmax_probability(model_,x,prob_estimates);
+					break;
+				case 3:
+					predict_label = predict_values(model_,x,prob_estimates);
+					break;
+			}
 			fprintf(output,"%g",predict_label);
 			for(j=0;j<model_->nr_class;j++)
 				fprintf(output," %g",prob_estimates[j]);
@@ -168,7 +179,7 @@ void do_predict(FILE *input, FILE *output)
 	}
 	else
 		info("Accuracy = %g%% (%d/%d)\n",(double) correct/total*100,correct,total);
-	if(flag_predict_probability)
+	if(prob_estimates)
 		free(prob_estimates);
 }
 
@@ -177,7 +188,11 @@ void exit_with_help()
 	printf(
 	"Usage: predict [options] test_file model_file output_file\n"
 	"options:\n"
-	"-b probability_estimates: whether to output probability estimates, 0 or 1 (default 0); currently for logistic regression only\n"
+	"-b probability_estimates:\n"
+	"    0: output only best label;\n"
+	"    1: output probabilities for logistic regression solver;\n"
+	"    2: output softmax probabilities;\n"
+	"    3: output raw scores.\n"
 	"-q : quiet mode (no outputs)\n"
 	);
 	exit(1);


### PR DESCRIPTION
Add support for softmax probabilities (-b2) and raw scores (-b3) to "predict" executable.
