### PR TITLE
Bump SHVER

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CXX ?= g++
 CC ?= gcc
 CFLAGS = -Wall -Wconversion -O3 -fPIC
 LIBS = blas/blas.a
-SHVER = 3
+SHVER = 4
 OS = $(shell uname)
 #LIBS = -lblas
 


### PR DESCRIPTION
Hi,

when upgrading LIBLINEAR from version 2.10 to version 2.30, I noticed that there were backwards-incompatible changes in the library. Specifically, the following symbols from the previous version are no longer available:
  * TRON::trcg -> changed to TRON::trcpg
  * find_parameters_C -> changed to find_parameters

Please update SHVER from 3 to 4 to indicate this change, so that programs compiled for the old version of the library (when building a shared library) don't accidentally use the new version.

Thanks,
Christian