### PR TITLE
Export get_decfun_rho and check_oneclass_model from liblinear.dll

### DIFF
--- a/linear.def
+++ b/linear.def
@@ -20,3 +20,5 @@ EXPORTS
     get_decfun_bias @18
     check_regression_model  @19
     find_parameters @20
+    get_decfun_rho @21
+    check_oneclass_model @22


### PR DESCRIPTION
`get_decfun_rho` and `check_oneclass_model` are used in the Python wrapper:

https://github.com/cjlin1/liblinear/blob/2381122d05bbb1e4ee24b522298dd548f0ec0d24/python/liblinear.py#L437

https://github.com/cjlin1/liblinear/blob/2381122d05bbb1e4ee24b522298dd548f0ec0d24/python/liblinear.py#L445