### PR TITLE
Adjust eps parameter comment in README: "stopping tolerance"

### DIFF
--- a/README
+++ b/README
@@ -390,7 +390,7 @@ in linear.h, so you can check the version number.
                 int solver_type;
 
                 /* these are for training only */
-                double eps;             /* stopping criteria */
+                double eps;             /* stopping tolerance */
                 double C;
                 double nu;              /* one-class SVM only */
                 int nr_weight;


### PR DESCRIPTION
The comment was changed in linear.h via https://github.com/cjlin1/liblinear/commit/7b0193baec9a443684e4a079ae4a2040971f67cf.
However, the code snippet in the README was not adjusted.