### PR TITLE
linear.cpp (check_parameter): only check value of p if L2R_L2LOSS_SVR.

### DIFF
--- a/linear.cpp
+++ b/linear.cpp
@@ -3712,7 +3712,7 @@ const char *check_parameter(const problem *prob, const parameter *param)
 	if(param->C <= 0)
 		return "C <= 0";
 
-	if(param->p < 0)
+	if(param->p < 0 && param->solver_type == L2R_L2LOSS_SVR)
 		return "p < 0";
 
 	if(prob->bias >= 0 && param->solver_type == ONECLASS_SVM)


### PR DESCRIPTION
The parameter `p` is only used by the L2R_L2LOSS_SVR solver so skip
checking its value unless using it.  This is important because it has
no default value meaning that we are effectively forcing the user to
set it even if they don't use it.

Specifically, I was not setting the value of p and my code was working
fine in Linux with gcc.  While porting the software to windows and
build with MSVC, then I started getting the "p < 0" error because it
was being set to some negative value.