### PR TITLE
Bump SHVER from 4 to 5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CXX ?= g++
 CC ?= gcc
 CFLAGS = -Wall -Wconversion -O3 -fPIC
 LIBS = blas/blas.a
-SHVER = 4
+SHVER = 5
 OS = $(shell uname)
 #LIBS = -lblas
 


### PR DESCRIPTION
Hi,

I was about to update the Debian package of LIBLINEAR and I believe that there is a recent change in the public interface that is backwards-incompatible, requiring a SHVER bump from 4 to 5.

Specifically, in [linear.h](https://github.com/cjlin1/liblinear/blob/master/linear.h), `struct param` and `struct model` were changed in a way that makes them incompatible with existing uses of the library:

- Existing code initializing a `struct param` will be unaware of the new `double nu` added before `double *init_sol`
- This also changes the size of `struct param`, which then affects `struct model` where it is used
