### PR TITLE
Set pointers to NULL after memory is freed

### DIFF
--- a/linear.cpp
+++ b/linear.cpp
@@ -3678,10 +3678,10 @@ double get_decfun_rho(const struct model *model_)
 
 void free_model_content(struct model *model_ptr)
 {
-	if(model_ptr->w != NULL)
-		free(model_ptr->w);
-	if(model_ptr->label != NULL)
-		free(model_ptr->label);
+	free(model_ptr->w);
+	model_ptr->w = NULL;
+	free(model_ptr->label);
+	model_ptr->label = NULL;
 }
 
 void free_and_destroy_model(struct model **model_ptr_ptr)
@@ -3691,17 +3691,18 @@ void free_and_destroy_model(struct model **model_ptr_ptr)
 	{
 		free_model_content(model_ptr);
 		free(model_ptr);
+		*model_ptr_ptr = NULL;
 	}
 }
 
 void destroy_param(parameter* param)
 {
-	if(param->weight_label != NULL)
-		free(param->weight_label);
-	if(param->weight != NULL)
-		free(param->weight);
-	if(param->init_sol != NULL)
-		free(param->init_sol);
+	free(param->weight_label);
+	param->weight_label = NULL;
+	free(param->weight);
+	param->weight = NULL;
+	free(param->init_sol);
+	param->init_sol = NULL;
 }
 
 const char *check_parameter(const problem *prob, const parameter *param)


### PR DESCRIPTION
This makes the `free`ing code equivalent to how libsvm does it.

Note that `free` does not require a NULL check as it is a no-op if the given pointer is NULL.